### PR TITLE
Change seq2seq import names

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,8 @@ from tensorlayer.cost import cross_entropy_seq, cross_entropy_seq_with_mask
 from tqdm import tqdm
 from sklearn.utils import shuffle
 from data.twitter import data
-from tensorlayer.models.Seq2seq import Seq2seq
-from tensorlayer.models.Seq2seqLuongAttention import Seq2seq_Attention
+from tensorlayer.models.seq2seq import Seq2seq
+from tensorlayer.models.seq2seq_with_attention import Seq2seqLuongAttention
 import os
 
 


### PR DESCRIPTION
Had the #37 problem. It looks like on in current version of tensorlayer import names changed.

These imports work with 
tensorflow 2.0.0-beta1
tensorlayer 2.1.0